### PR TITLE
Support relations

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -34,7 +34,8 @@ export type ColumnType =
   | "checkbox"
   | "title"
   | "multi_select"
-  | "number";
+  | "number"
+  | "relation";
 
 export type ColumnSchemaType = {
   name: string;

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -35,6 +35,10 @@ export const getNotionValue = (
       return val[0][0].split(",") as string[];
     case "number":
       return Number(val[0][0]);
+    case "relation":
+      return val
+        .filter(([symbol]) => symbol === "‣")
+        .map(([_, relation]) => relation![0][1] as string);
     default:
       console.log({ val, type });
       return "Not supported";


### PR DESCRIPTION
Notion relations appear to be encoded like this:

```
[
  ["‣", ["p", "1DC1624C-8FCC-43E7-A07E-B41C297407D4"]],
  [","],
  ["‣", ["p", "7D80DB84-022E-41E8-B7FB-8E454CF14AC7"]],
  ...
  [","],
  ["‣", ["p", "2D2AA7BB-3A97-434F-8A33-4E7FD690E4C3"]]
]
```

I transform values of the shape:

```
[
  ["‣", [_, "id0"]],
  ...
  ["‣", [_, "idn"]]
]
```

into `["id0", ..., "idn"]`.
    