### PR TITLE
Add support for recursive blocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,15 @@ export type Handler = (
   notionToken?: string
 ) => Promise<Response> | Response;
 
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "*",
+  "Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
+};
+
 const router = new Router<Handler>();
 
-router.options("*", () => new Response("", { headers: {} }));
+router.options("*", () => new Response(null, { headers: corsHeaders }));
 router.get("/v1/page/:pageId", pageRoute);
 router.get("/v1/table/:pageId", tableRoute);
 router.get("/v1/user/:userId", userRoute);


### PR DESCRIPTION
Some async blocks can also contain sub-blocks that need to be fetched recursively.

This page shows an example of this: https://lownocode.dev/e68c18a4-6190-4eb5-a2dd-c3748e76b893