### PR TITLE
Respect cache headers

### DIFF
--- a/src/get-cache-key.ts
+++ b/src/get-cache-key.ts
@@ -1,0 +1,16 @@
+export function getCacheKey(request: Request): string | null {
+  const pragma = request.headers.get("pragma");
+  if (pragma === "no-cache") {
+    return null;
+  }
+
+  const cacheControl = request.headers.get("cache-control");
+  if (cacheControl) {
+    const directives = new Set(cacheControl.split(",").map((s) => s.trim()));
+    if (directives.has("no-store") || directives.has("no-cache")) {
+      return null;
+    }
+  }
+
+  return request.url;
+}

--- a/src/response.ts
+++ b/src/response.ts
@@ -10,6 +10,7 @@ export const createResponse = (
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Content-Type": "application/json",
       ...headers,
     },
   });


### PR DESCRIPTION
Fixes #11.

Also adds `content-type: application/json` to all responses since they're currently returned as `text/plain`.

Note that respecting these cache headers is really useful when debugging via Chrome devtools.