### PR TITLE
Return working image url inside table

### DIFF
--- a/src/routes/table.ts
+++ b/src/routes/table.ts
@@ -43,7 +43,7 @@ export const getTableData = async (
       const val = td.value.properties[key];
       if (val) {
         const schema = collectionRows[key];
-        row[schema.name] = raw ? val : getNotionValue(val, schema.type);
+        row[schema.name] = raw ? val : getNotionValue(val, schema.type, td);
         if (schema.type === "person" && row[schema.name]) {
           const users = await fetchNotionUsers(row[schema.name] as string[]);
           row[schema.name] = users as any;


### PR DESCRIPTION
- Prefix with `notion.so/image/`
- Add required query params

Somewhat breaking, since the original s3 `url` is now `rawURL`. Makes sense still because I the prefixed url is what you want 99% of the time.