### PR TITLE
Add support for url, email, phone_number types

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -38,7 +38,10 @@ export type ColumnType =
   | "multi_select"
   | "number"
   | "relation"
-  | "file";
+  | "file"
+  | "email"
+  | "phone_number"
+  | "url";
 
 export type ColumnSchemaType = {
   name: string;

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -39,6 +39,9 @@ export const getNotionValue = (
     case "title":
       return getTextContent(val);
     case "select":
+    case "email":
+    case "phone_number":
+    case "url":
       return val[0][0];
     case "multi_select":
       return val[0][0].split(",") as string[];


### PR DESCRIPTION
These columns are represented as simple strings. Here's how notion-py handles them:

https://github.com/jamalex/notion-py/blob/ae3dee89c246f2f76b3b9ae72521bb6f0d59700f/notion/collection.py#L446