### PR TITLE
fix: notion api update issue

### DIFF
--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -16,7 +16,7 @@ interface INotionParams {
 }
 
 const loadPageChunkBody = {
-  limit: 999,
+  limit: 100,
   cursor: { stack: [] },
   chunkNumber: 0,
   verticalColumns: false,
@@ -56,7 +56,7 @@ const queryCollectionBody = {
   query: { aggregations: [{ property: "title", aggregator: "count" }] },
   loader: {
     type: "table",
-    limit: 999,
+    limit: 100,
     searchQuery: "",
     userTimeZone: "Europe/Vienna",
     userLocale: "en",


### PR DESCRIPTION
As the Notion API changes, if you don't adjust the limit to 100, you will get a 1101 Cloudflare Worker error.