### PR TITLE
fix(table): allow loading more than 100 entries

### DIFF
--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -56,7 +56,7 @@ const queryCollectionBody = {
   query: { aggregations: [{ property: "title", aggregator: "count" }] },
   loader: {
     type: "table",
-    limit: 100,
+    limit: 999,
     searchQuery: "",
     userTimeZone: "Europe/Vienna",
     userLocale: "en",


### PR DESCRIPTION
With notion API changes, you cannot query more than 100 for `loadPageChunkBody` but table entries gets unchanged for now