### PR TITLE
Fix broken pending block fetching

### DIFF
--- a/src/routes/page.ts
+++ b/src/routes/page.ts
@@ -16,15 +16,11 @@ export async function pageRoute(req: HandlerRequest) {
   let allBlockKeys;
 
   while (true) {
-    allBlockKeys = Object.keys(allBlocks);
 
-    const pendingBlocks = allBlockKeys.flatMap((blockId) => {
-      const block = allBlocks[blockId];
-      const content = block.value && block.value.content;
+    allBlockKeys = allBlocks[pageId!].value.content
 
-      return content && block.value.type !== "page"
-        ? content.filter((id: string) => !allBlocks[id])
-        : [];
+    const pendingBlocks = allBlockKeys!.filter((blockId) => {
+      return !allBlocks.hasOwnProperty(blockId)
     });
 
     if (!pendingBlocks.length) {


### PR DESCRIPTION
This PR aims to address the issue raised in #51 and #41 
When the page is longer than 100 blocks, it cannot be retrieved in a single call to the Notion private API. There was code to go through the "pagination" to retrieve missing blocks, but it was not working. I replaced it something simpler that does the following:
- Get the list of all block ids on the page
- Check which one are missing from the list of blocks we have
- Fetch missing blocks
- Do that again if there are still missing blocks.

Because my code is simpler, I may have broken other things. I don't have any knowledge about the Notion private API, so if you have more experience, please review the change made. 