### PR TITLE
Fix missing/pending blocks

### DIFF
--- a/src/routes/page.ts
+++ b/src/routes/page.ts
@@ -16,11 +16,15 @@ export async function pageRoute(req: HandlerRequest) {
   let allBlockKeys;
 
   while (true) {
+    allBlockKeys = Object.keys(allBlocks);
 
-    allBlockKeys = allBlocks[pageId!].value.content
+    const pendingBlocks = allBlockKeys.flatMap((blockId) => {
+      const block = allBlocks[blockId];
+      const content = block.value && block.value.content;
 
-    const pendingBlocks = allBlockKeys!.filter((blockId) => {
-      return !allBlocks.hasOwnProperty(blockId)
+      return content && block.value.type !== "page"
+        ? content.filter((id: string) => !allBlocks[id])
+        : [];
     });
 
     if (!pendingBlocks.length) {

--- a/src/routes/page.ts
+++ b/src/routes/page.ts
@@ -22,9 +22,12 @@ export async function pageRoute(req: HandlerRequest) {
       const block = allBlocks[blockId];
       const content = block.value && block.value.content;
 
-      return content && block.value.type !== "page"
-        ? content.filter((id: string) => !allBlocks[id])
-        : [];
+      if (!content || (block.value.type === "page" && blockId !== pageId!)) {
+        // skips pages other than the requested page
+        return [];
+      }
+
+      return content.filter((id: string) => !allBlocks[id]);
     });
 
     if (!pendingBlocks.length) {


### PR DESCRIPTION
The #52 fix introduced some new problems with missing blocks:
- https://github.com/splitbee/notion-api-worker/issues/57
- https://github.com/splitbee/react-notion/issues/79;

---

The #52 fix only fetched potential blocks from the page block but ignored other `content` of child blocks → _e.g. the react-tester page `toggle` block doesn't contain its child `content`_

The original page logic fetched potential blocks by going over `content` of _non-page_ blocks.

---

**In this PR:**
- https://github.com/splitbee/notion-api-worker/pull/52/commits/bf8c9c50b8ff75eda153b1efa6b2e121c9f4b08c is reverted
- new logic is added that keeps **_both_** the current page `content` blocks and non-page `content` blocks