### PR TITLE
Add experimental `syncRecordValues` fix

### DIFF
--- a/src/api/notion.ts
+++ b/src/api/notion.ts
@@ -129,12 +129,11 @@ export const fetchBlocks = async (
   return await fetchNotionData<LoadPageChunkData>({
     resource: "syncRecordValues",
     body: {
-      recordVersionMap: {
-        block: blockList.reduce((obj, blockId) => {
-          obj[blockId] = -1;
-          return obj;
-        }, {} as { [key: string]: -1 }),
-      },
+      requests: blockList.map((id) => ({
+        id,
+        table: "block",
+        version: -1,
+      })),
     },
     notionToken,
   });


### PR DESCRIPTION
Fix for recent bug (`syncRecordValues` doesn't return blocks any more)

> `notion-client` and potion seem to use a similar logic. Although, I don't know if this breaks anything else.

- Closes https://github.com/splitbee/notion-api-worker/issues/64