### PR TITLE
Fix: Add try catch on Date field to prevent app from crashing

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -34,8 +34,12 @@ export const getNotionValue = (
     case "checkbox":
       return val[0][0] === "Yes";
     case "date":
-      if (val[0][1]![0][0] === "d") return val[0]![1]![0]![1]!.start_date;
-      else return "";
+      try {
+        if (val[0][1]![0][0] === "d") return val[0]![1]![0]![1]!.start_date;
+        else return "";
+      } catch (e) {
+        return "";
+      }
     case "title":
       return getTextContent(val);
     case "select":


### PR DESCRIPTION
Hi,

There is this weird error with the table field type Date. 
Sometimes it's `undefined` for some reason.

I replicated the problem here on [this Notion table](https://thirsty-breakfast-a18.notion.site/4726db7efa7e48fea31b564f566182b1?v=7966dfc0e036476d9cf776b0a9e67432).

When the [request for this table](https://notion-api.splitbee.io/v1/table/4726db7efa7e48fea31b564f566182b1) is sent to the Cloudflare worker this will crash:
 
<img width="500" alt="Screenshot 2024-07-02 at 10 50 15" src="https://github.com/splitbee/notion-api-worker/assets/32492427/ebcee2f3-5c1f-4860-b039-ec13b4e20613">

Adding a try-catch prevents this to happen.

@tobiaslins 
