### PR TITLE
Query Collection Requires Specific Base URL

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -74,6 +74,10 @@ export interface BaseValueType {
   last_edited_by_table: string;
   last_edited_by_id: string;
   content?: string[];
+  space_id?: string;
+  format?: {
+    site_id?: string;
+  };
 }
 
 export interface CollectionType {

--- a/src/routes/page.ts
+++ b/src/routes/page.ts
@@ -5,6 +5,7 @@ import { getTableData } from "./table";
 import { BlockType, CollectionType, HandlerRequest } from "../api/types";
 
 export async function pageRoute(req: HandlerRequest) {
+  
   const pageId = parsePageId(req.params.pageId);
   const page = await fetchPageById(pageId!, req.notionToken);
 
@@ -75,6 +76,7 @@ export async function pageRoute(req: HandlerRequest) {
         coll,
         collView.value.id,
         req.notionToken,
+        undefined,
         true
       );
 

--- a/src/routes/table.ts
+++ b/src/routes/table.ts
@@ -5,6 +5,7 @@ import {
   CollectionType,
   RowType,
   HandlerRequest,
+  BlockType,
 } from "../api/types";
 import { createResponse } from "../response";
 
@@ -12,12 +13,14 @@ export const getTableData = async (
   collection: CollectionType,
   collectionViewId: string,
   notionToken?: string,
+  blockData?: BlockType,
   raw?: boolean
 ) => {
   const table = await fetchTableData(
     collection.value.id,
     collectionViewId,
-    notionToken
+    notionToken,
+    blockData
   );
 
   const collectionRows = collection.value.schema;
@@ -77,10 +80,14 @@ export async function tableRoute(req: HandlerRequest) {
     (k) => page.recordMap.collection_view[k]
   )[0];
 
+  const blockData = page.recordMap.block[pageId!];
+
   const { rows } = await getTableData(
     collection,
     collectionView.value.id,
-    req.notionToken
+    req.notionToken,
+    blockData
+
   );
 
   return createResponse(rows);


### PR DESCRIPTION
Feel free to use this as a reference, I played around with some ideas after following the two other issues on similar repos:

https://github.com/splitbee/notion-api-worker/issues/89#issuecomment-3382344291

As far as I can tell this is a Notion internal change to require the baseURL to be specific to the page rather than the global path. Not sure if this is a bug on Notion's side that they will eventually address or if this is the new standard for them.

I tested this with my own workspace and it worked great, but I haven't thoroughly tested it.